### PR TITLE
[parity-6230] fix overflow bug while parsing an invalid device interface path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "libusb-sys"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>"]
 description = "FFI bindings for libusb."
 license = "MIT"

--- a/libusb/libusb/os/windows_usb.c
+++ b/libusb/libusb/os/windows_usb.c
@@ -552,7 +552,7 @@ static SP_DEVICE_INTERFACE_DETAIL_DATA_A *get_interface_details_filter(struct li
 static char *parse_device_interface_path(const char *interface_path)
 {
 	char *device_id, *guid_start;
-	unsigned int i, len;
+	int i, len;
 
 	len = safe_strlen(interface_path);
 	if (len < 4) {


### PR DESCRIPTION
Fixes bug causing crash in windows discoverd in paritytech/parity#6230

The crash is caused by an overflow when trying to set the unsigned integer **length** to a negative number while parsing an invalid device interface path