### PR TITLE
Add back links attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/dcuddeback/libusb-sys"
 repository = "https://github.com/dcuddeback/libusb-sys.git"
 readme = "README.md"
 keywords = ["usb", "libusb", "hardware", "bindings"]
-
+links = "usb-1.0"
 build = "build.rs"
 
 [dependencies]


### PR DESCRIPTION
We cannot link twice to libusb anyway because of conflicting symbol names, so it doesn't make sense to remove this attribute.

Adding it back will allow using a local library override.